### PR TITLE
Nowy wykres do atk/def

### DIFF
--- a/MINI_2016/Projekty/Projekt01/grzybowskij_dyszynskij/cardGenerator.R
+++ b/MINI_2016/Projekty/Projekt01/grzybowskij_dyszynskij/cardGenerator.R
@@ -63,17 +63,22 @@ colorPlot <- function(deck){
           axis.ticks.y=element_blank())
 }
 
-costBarPlot <- function(deck){
+costBarPlot <- function(deck, maxCost, maxCount){
   ggplot(deck[!is.na(deck$manaCost),], aes(x=manaCost, fill=manaCost)) +
     geom_bar() +
-    coord_cartesian(xlim = c(0, maxCost), ylim = c(0, maxCost)) +
+    coord_cartesian(xlim = c(0, maxCost), ylim = c(0, maxCount)) +
     scale_x_continuous(breaks=0:maxCost) +
     scale_y_continuous(breaks=0:maxCount) +
     theme(panel.grid.major = element_line(colour = "blue"))
 }
 
-creatureTypes <- function(desks){
-  ggplot(decks,aes(x=battleType, fill = deckIndex)) + coord_flip()+ geom_bar(position="fill")
+creatureTypes <- function(decks) {
+  atkDef = as.data.frame(table(decks[, c("attack", "defence", "deckIndex")]))
+  atkDef = atkDef[atkDef$Freq > 0,]
+  p = ggplot(atkDef,aes(x=attack, y=defence, color=deckIndex, size=Freq, alpha=0.5))
+  p = p + geom_point()
+  p = p + guides(size=FALSE, alpha=FALSE)
+  p
 }
 
 getLegend <- function(a.gplot) {
@@ -95,13 +100,13 @@ maxCount = max(max(hist(deck1$manaCost, plot=FALSE)$counts), max(hist(deck2$mana
 
 t1 = typePlot(deck1) + theme(legend.position="none")
 c1 = colorPlot(deck1) + theme(legend.position="right")
-cost1 = costBarPlot(deck1)
+cost1 = costBarPlot(deck1, maxCost, maxCount)
 
 t2 = typePlot(deck2) + theme(legend.position="none")
 c2 = colorPlot(deck2)
-cost2 = costBarPlot(deck2) + coord_cartesian(xlim = c(0, maxCost), ylim = c(0, maxCost))
+cost2 = costBarPlot(deck2, maxCost, maxCount)
 
-balancePlot <- creatureTypes(decks) + themeNoLabels + theme(legend.position="none") + theme(axis.text.y=element_text())
+balancePlot <- creatureTypes(decks)
 
 #p1 = multiplot(t1,c1,cost1, layout= matrix(c(1,3,2,3), nrow=2))
 #p2 = multiplot(t2,c2,cost2, layout= matrix(c(1,3,2,3), nrow=2))

--- a/MINI_2016/Projekty/Projekt01/grzybowskij_dyszynskij/cardGenerator.R
+++ b/MINI_2016/Projekty/Projekt01/grzybowskij_dyszynskij/cardGenerator.R
@@ -25,7 +25,7 @@ cards$defence <- rep(NA, nrow(cards))
 cards$defence[cards$type == "Creature"] <- sample(1:5, replace=TRUE, size=length(cards$defence[cards$type == "Creature"]))
 
 ratios = cards$attack/cards$defence
-cards$battleType <- rep(0, nrow(cards))
+cards$battleType <- rep(NA, nrow(cards))
 cards$battleType[ratios < 1] <- "defender"
 cards$battleType[ratios == 1] <- "universal"
 cards$battleType[ratios > 1] <- "attacker"
@@ -56,7 +56,8 @@ colorPlot <- function(deck){
   ggplot(deck, aes(x=1, fill=color)) +
     geom_bar(position="fill") +
     guides(fill = FALSE) +
-    
+    coord_flip() +
+    scale_y_continuous() +
     theme(axis.title.y=element_blank(),
           axis.text.y=element_blank(),
           axis.ticks.y=element_blank())
@@ -87,6 +88,7 @@ deck2 = generateDeck(2)
 decks <- rbind(deck1,deck2)
 
 typeLegend <- getLegend(typePlot(decks))
+#colorLegend <- getLegend(costBarPlot(decks))
 
 maxCost = max(decks$manaCost, na.rm=T)
 maxCount = max(max(hist(deck1$manaCost, plot=FALSE)$counts), max(hist(deck2$manaCost, plot=FALSE)$counts))
@@ -105,8 +107,8 @@ balancePlot <- creatureTypes(decks) + themeNoLabels + theme(legend.position="non
 #p2 = multiplot(t2,c2,cost2, layout= matrix(c(1,3,2,3), nrow=2))
 #multiplot(p1,p2)
 #multiplot(t1, t2, c1, c2 ,cost1, cost2, balancePlot, layout= matrix(c(1,2,3,4,5,6,7,7), nrow=4, byrow = T))
-row1 <- grid.arrange(t1, typeLegend, t2, ncol = 3)
-row2 <- grid.arrange(c1, c2, ncol = 2)
-row3 <- grid.arrange(cost1, cost2, ncol = 2)
+row1 <- grid.arrange(t1, typeLegend, t2, nrow = 1, widths = c(10, 2, 10))
+row2 <- grid.arrange(c1, c2, nrow = 1)
+row3 <- grid.arrange(cost1, cost2, nrow = 1)
 row4 <- balancePlot
 grid.arrange(row1, row2, row3, row4, ncol = 1)

--- a/MINI_2016/Projekty/Projekt01/grzybowskij_dyszynskij/cardGenerator.R
+++ b/MINI_2016/Projekty/Projekt01/grzybowskij_dyszynskij/cardGenerator.R
@@ -1,9 +1,14 @@
+library(ggplot2)
+library(grid)
+library(gridExtra)
+
 generateDeck <- function(deckIndex){
 manaCost <-   c(sample(c(NA), 24, replace=T),ceiling(abs(rnorm(36, 3.5, 2))))
 
 cards <- data.frame(manaCost)
 cards$deckIndex <- factor(deckIndex)
 
+cards$attack <- rep(NA, nrow(cards))
 cards$type <- c(sample(c(NA), 24, replace=T),runif(36))
 cards$type[is.na(cards$type)] <- "Land"
 cards$type[cards$type < 0.45] <- "Creature"
@@ -14,15 +19,16 @@ cards$type[cards$type < 1.01] <- "Artifact"
 
 #ggplot(cards) + geom_bar(mapping = aes(x=1, fill = type), position = "fill") +  coord_polar(theta = "y")
 
-cards$attack <- NA
-cards$attack[cards$type == "Creature"] <- sample(1:5,replace=TRUE)
-cards$defence <- NA
-cards$defence[cards$type == "Creature"] <- sample(1:5,replace=TRUE)
+cards$attack <- rep(NA, nrow(cards))
+cards$attack[cards$type == "Creature"] <- sample(1:5, replace=TRUE, size=length(cards$attack[cards$type == "Creature"]))
+cards$defence <- rep(NA, nrow(cards))
+cards$defence[cards$type == "Creature"] <- sample(1:5, replace=TRUE, size=length(cards$defence[cards$type == "Creature"]))
 
-cards$battleType <- cards$attack/cards$defence
-cards$battleType[cards$battleType < 1] <- "defender"
-cards$battleType[cards$battleType == 1] <- "universal"
-cards$battleType[as.numeric(cards$battleType) > 1] <- "attacker"
+ratios = cards$attack/cards$defence
+cards$battleType <- rep(0, nrow(cards))
+cards$battleType[ratios < 1] <- "defender"
+cards$battleType[ratios == 1] <- "universal"
+cards$battleType[ratios > 1] <- "attacker"
 
 colors <- c("red", "blue", "green")
 colorsProbs <- c(1, 1, 0.5)
@@ -57,7 +63,7 @@ colorPlot <- function(deck){
 }
 
 costBarPlot <- function(deck){
-  ggplot(deck, aes(x=manaCost, fill=manaCost)) +
+  ggplot(deck[!is.na(deck$manaCost),], aes(x=manaCost, fill=manaCost)) +
     geom_bar() +
     coord_cartesian(xlim = c(0, maxCost), ylim = c(0, maxCost)) +
     scale_x_continuous(breaks=0:maxCost) +
@@ -69,14 +75,23 @@ creatureTypes <- function(desks){
   ggplot(decks,aes(x=battleType, fill = deckIndex)) + coord_flip()+ geom_bar(position="fill")
 }
 
+getLegend <- function(a.gplot) {
+  tmp <- ggplot_gtable(ggplot_build(a.gplot))
+  leg <- which(sapply(tmp$grobs, function(x) x$name) == "guide-box")
+  legend <- tmp$grobs[[leg]]
+  legend
+}
+
 deck1 = generateDeck(1)
 deck2 = generateDeck(2)
 decks <- rbind(deck1,deck2)
 
+typeLegend <- getLegend(typePlot(decks))
+
 maxCost = max(decks$manaCost, na.rm=T)
 maxCount = max(max(hist(deck1$manaCost, plot=FALSE)$counts), max(hist(deck2$manaCost, plot=FALSE)$counts))
 
-t1 = typePlot(deck1) + theme(legend.position="right")
+t1 = typePlot(deck1) + theme(legend.position="none")
 c1 = colorPlot(deck1) + theme(legend.position="right")
 cost1 = costBarPlot(deck1)
 
@@ -89,4 +104,9 @@ balancePlot <- creatureTypes(decks) + themeNoLabels + theme(legend.position="non
 #p1 = multiplot(t1,c1,cost1, layout= matrix(c(1,3,2,3), nrow=2))
 #p2 = multiplot(t2,c2,cost2, layout= matrix(c(1,3,2,3), nrow=2))
 #multiplot(p1,p2)
-multiplot(t1, t2, c1, c2 ,cost1, cost2, balancePlot, layout= matrix(c(1,2,3,4,5,6,7,7), nrow=4, byrow = T))
+#multiplot(t1, t2, c1, c2 ,cost1, cost2, balancePlot, layout= matrix(c(1,2,3,4,5,6,7,7), nrow=4, byrow = T))
+row1 <- grid.arrange(t1, typeLegend, t2, ncol = 3)
+row2 <- grid.arrange(c1, c2, ncol = 2)
+row3 <- grid.arrange(cost1, cost2, ncol = 2)
+row4 <- balancePlot
+grid.arrange(row1, row2, row3, row4, ncol = 1)


### PR DESCRIPTION
Wrzuciłem też kilka moich mniejszych poprawek, bo inaczej miałbym konflikt.

Rzuć okiem czy wykres teraz dobrze wygląda. To alpha 0.5 jest w miarę znośne.

Rozmiar kropki można by zamienić na pierwiastek z liczności albo chociaż podzielić przez 2. Nie wiem jak będzie bardziej czytelnie.
O tym w sumie były zajęcia: że obszarowe wykresy są mało czytelne.
Najbardziej by chyba pasowało przedstawić jako "chmurę" kropek, ale nie wiem jak ją uporządkować żeby nie było chaosu.
